### PR TITLE
chore(ci): harden permissions, catch release-only feature-gated bugs

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -7,6 +7,9 @@ on:
     branches: [ main ]
   workflow_dispatch:  # Allows manual triggering
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   TEST_S3_BUCKET: test-integration-bucket

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -34,6 +37,11 @@ jobs:
         # Only lint arkavo-rs package: excludes fpssdk (Apple copyrighted vendor code)
         # Allow unexpected-cfgs: ink macros use cfg(feature = "std") which isn't in our features
         run: cargo clippy --package arkavo-rs --lib --bin arks -- -D warnings -A mismatched-lifetime-syntaxes -A unexpected-cfgs
+      - name: release typecheck (all features)
+        # `cargo check --release` activates #[cfg(not(debug_assertions))] code
+        # that the default debug build skips. Includes fairplay-gated paths:
+        # `check` does not link, so libfpscrypto is not required here.
+        run: cargo check --release --bin arks --features fairplay,c2pa_signing
       - name: format
         run: |
           # Format check excluding vendor/ (copyrighted Apple SDK code)
@@ -48,8 +56,10 @@ jobs:
         with:
           targets: x86_64-unknown-linux-gnu
       - name: Build
+        # Build with c2pa_signing (no native deps); fairplay needs Apple SDK
+        # binaries not available in CI and is covered by the release typecheck.
         run: |
-          cargo build --release --target x86_64-unknown-linux-gnu --bin arks
+          cargo build --release --target x86_64-unknown-linux-gnu --bin arks --features c2pa_signing
           strip target/x86_64-unknown-linux-gnu/release/arks
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/src/modules/media_api.rs
+++ b/src/modules/media_api.rs
@@ -858,7 +858,7 @@ async fn handle_fairplay_key_request(
                 payload.asset_id
             );
             log_key_request_error(
-                state,
+                &state,
                 &payload,
                 KeyRequestResult::InvalidRequest,
                 timer.elapsed_ms(),


### PR DESCRIPTION
## Summary

Three small but related cleanups:

1. **Bugfix** — `src/modules/media_api.rs:861` passes `state` (an `Arc<MediaApiState>`) where `&state` is required. The call sits inside `#[cfg(feature = "fairplay")]` + `#[cfg(not(debug_assertions))]`, so it only compiles when both fairplay is enabled AND we're in release mode. The first production release build after the recent merges broke on this. Existing local debug builds and the pre-existing CI never exercised this path.

2. **Release typecheck step** — adds `cargo check --release --bin arks --features fairplay,c2pa_signing` to the Rust workflow's `check` job. `cargo check` doesn't link, so `libfpscrypto` isn't required — but it does activate `cfg(not(debug_assertions))` and feature-gated code, which is what would have caught (1).

3. **CodeQL Actions hardening** — adds `permissions: contents: read` to both `rust.yaml` and `integration-tests.yaml`. Resolves the CodeQL "Workflow does not contain permissions" finding by replacing the broad default `GITHUB_TOKEN` scope with the minimal read-only one these jobs need.

Also adds `--features c2pa_signing` to the existing release `build` job so its artifact more closely matches the production binary.

## Test plan

- [ ] CI green — in particular, the new `release typecheck (all features)` step passes.
- [ ] Confirm no new CodeQL/Gitar findings about permissions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)