### PR TITLE
feat(proxy): forward /.well-known/opentdf-configuration to upstream platform

### DIFF
--- a/docs/platform-proxy.md
+++ b/docs/platform-proxy.md
@@ -18,6 +18,8 @@ modern ZTDF rewrap (handled by platform).
 - **`rest`** — `/kas/v2/rewrap` and `/kas/v2/kas_public_key` forward to platform (replaces the local `http_rewrap` shim).
 - **`both`** — `connect` + `rest`.
 
+Whenever the mode is anything other than `off`, `/.well-known/opentdf-configuration` is also forwarded to the upstream platform so clients see the authoritative discovery document.
+
 `/ws` (custom NanoTDF binary protocol) always stays local; `/media/v1/*` and `/c2pa/v1/*` are always local.
 
 ## KAS URL identity caveat
@@ -40,7 +42,7 @@ them through, you must either:
 - WebSocket `/ws` (NanoTDF rewrap, contracts, NATS push) — arks-only.
 - `/media/v1/*` (TDF3 media DRM, session manager).
 - `/c2pa/v1/*` (C2PA signing).
-- `/.well-known/apple-app-site-association`.
+- `/.well-known/apple-app-site-association` (always local; `/.well-known/opentdf-configuration` is forwarded when the proxy is on).
 
 ## What's not done
 

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -871,6 +871,23 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .with_state(rewrap_state)
     };
 
+    // Platform discovery — `/.well-known/opentdf-configuration` is published by
+    // the upstream platform and lists its endpoints/keys. Forward whenever any
+    // proxying is on so clients see the authoritative document.
+    let wellknown_router = if proxy_mode.forwards_discovery() {
+        let state = platform_proxy_state
+            .clone()
+            .expect("platform_proxy_state must exist when forwards_discovery()");
+        Router::new()
+            .route(
+                "/.well-known/opentdf-configuration",
+                get(platform_proxy::proxy),
+            )
+            .with_state(state)
+    } else {
+        Router::new()
+    };
+
     // ConnectRPC routes — only mounted when proxying is enabled.
     let connect_router = if proxy_mode.forwards_connect() {
         let state = platform_proxy_state
@@ -937,6 +954,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         )
         .with_state(ws_state)
         .merge(opentdf_router)
+        .merge(wellknown_router)
         .merge(connect_router)
         .merge(media_router)
         .merge(c2pa_router)

--- a/src/modules/platform_proxy.rs
+++ b/src/modules/platform_proxy.rs
@@ -48,6 +48,12 @@ impl ProxyMode {
     pub fn forwards_rest(self) -> bool {
         matches!(self, ProxyMode::Rest | ProxyMode::Both)
     }
+
+    /// `/.well-known/opentdf-configuration` is platform-authoritative discovery.
+    /// Whenever any proxying is on, defer to the upstream document.
+    pub fn forwards_discovery(self) -> bool {
+        !matches!(self, ProxyMode::Off)
+    }
 }
 
 /// Shared state for the reverse-proxy handler.
@@ -231,15 +237,19 @@ mod mode_tests {
     fn forwarding_predicates() {
         assert!(!ProxyMode::Off.forwards_connect());
         assert!(!ProxyMode::Off.forwards_rest());
+        assert!(!ProxyMode::Off.forwards_discovery());
 
         assert!(ProxyMode::Connect.forwards_connect());
         assert!(!ProxyMode::Connect.forwards_rest());
+        assert!(ProxyMode::Connect.forwards_discovery());
 
         assert!(!ProxyMode::Rest.forwards_connect());
         assert!(ProxyMode::Rest.forwards_rest());
+        assert!(ProxyMode::Rest.forwards_discovery());
 
         assert!(ProxyMode::Both.forwards_connect());
         assert!(ProxyMode::Both.forwards_rest());
+        assert!(ProxyMode::Both.forwards_discovery());
     }
 }
 


### PR DESCRIPTION
## Summary

OpenTDF clients fetch \`/.well-known/opentdf-configuration\` to discover the KAS endpoints, OIDC issuer, registered key IDs, and feature flags. The upstream opentdf-platform serves this document on the same port as its other KAS routes; arks was returning 404 for it because the reverse-proxy work in #54 only covered \`/kas/v2/*\` (REST) and \`/kas.AccessService/*\` (ConnectRPC).

Verified locally: \`http://127.0.0.1:8181/.well-known/opentdf-configuration\` → 200 with discovery JSON; public \`https://platform.arkavo.net/.well-known/opentdf-configuration\` → 404 (pre-fix).

## Changes

- Add \`ProxyMode::forwards_discovery()\` predicate — true for any mode except \`Off\`.
- Add a small \`wellknown_router\` in \`main.rs\` that mounts \`GET /.well-known/opentdf-configuration\` against the existing \`platform_proxy::proxy\` handler when discovery is enabled.
- \`/.well-known/apple-app-site-association\` continues to be served locally; the two routes are unrelated handlers and coexist fine.
- Document the new behavior in \`docs/platform-proxy.md\`.
- Extend the existing \`forwarding_predicates\` test to cover the new predicate.

## Design note

Discovery is forwarded for **all** non-Off modes (\`connect\`, \`rest\`, \`both\`), not just \`both\`. Rationale: if any KAS path is proxied at all, the upstream platform owns the authoritative endpoint list, so its discovery doc should too. Deployments running asymmetric modes should be aware that the published doc may advertise endpoints not handled by the local arks instance — this is documented.

## Test plan

- [x] \`cargo test --bins platform_proxy\` — 15/15 pass including extended \`forwarding_predicates\`.
- [ ] CI green.
- [ ] After deploy: \`curl https://platform.arkavo.net/.well-known/opentdf-configuration\` returns 200 + the upstream JSON body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)